### PR TITLE
white font on default was messing with the other button types.

### DIFF
--- a/lib/assets/stylesheets/oc/buttons.scss
+++ b/lib/assets/stylesheets/oc/buttons.scss
@@ -9,11 +9,6 @@
   .btn {
     background-image: none;
     border: none;
-    color: white;
-
-    &:hover {
-      color: white;
-    }
   }
 
   // A large button.
@@ -29,9 +24,10 @@
   // Styleguide Buttons.Button.Primary
   .btn-primary {
     background-color: $chef-primary-2-color;
-
+    color: white;
     &:hover {
       background-color: darken($chef-primary-2-color, 5%);
+      color: white;
     }
   }
 }


### PR DESCRIPTION
 Moving white font to the primary button where the white is needed.

Since Bootstrap default btn button is gray, the white font need to be moved to the primary button.
@smith 
