### PR TITLE
use 'Account' instead of 'Sign In' in header

### DIFF
--- a/templates/corpsite_header.html
+++ b/templates/corpsite_header.html
@@ -11,7 +11,7 @@
             </div>
             <div class='sign-in-container text-right'>
               <div class='login-links'>
-                <a href='//www.getchef.com/account/' style='white-space:nowrap'>Sign In</a>
+                <a href='//www.getchef.com/account/' style='white-space:nowrap'>Account</a>
                 <a href='https://manage.opscode.com/'>Management Console</a>
               </div>
             </div>


### PR DESCRIPTION
This will help when we add oc-web-core to accountmanagement and id.
