### PR TITLE
Add some URL helpers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,5 @@ gemspec
 
 group :development, :test do
   gem 'rspec'
+  gem 'rspec-its'
 end

--- a/lib/oc/web/core/url_helpers.rb
+++ b/lib/oc/web/core/url_helpers.rb
@@ -4,89 +4,80 @@ class Chef
   module Web
     module Core
       module URLHelpers
-
-        class Site
-          attr_accessor :subdomain, :domain
-
-          def initialize(subdomain, domain=nil)
-            @subdomain = subdomain
-            @domain = domain || chef_domain
-          end
-
-          def hostname
-            "#{subdomain}.#{domain}"
-          end
-
-          def non_secure_url
-            "http://#{hostname}"
-          end
-
-          def secure_url
-            "https://#{hostname}"
-          end
-
-          def canonical_url
-            secure_url
-          end
-
-          def protocol_relative_url
-            "//#{hostname}"
-          end
-
-          alias_method :url, :canonical_url
-          alias_method :to_s, :canonical_url
-
-          private
-
-            def chef_domain
-              ENV['CHEF_DOMAIN'] || 'getchef.com'
-            end
+        
+        def chef_domain
+          ENV['CHEF_DOMAIN'] || 'chef.io'
         end
 
-        def opscode_domain
-          'opscode.com'
+        def chef_server_url
+          ENV['CHEF_SERVER_URL'] || "https://api.#{chef_domain}"
         end
 
-        def corpsite
-          @_corpsite ||= Site.new('www')
+        def chef_www_url(extra = nil)
+          url = ENV['CHEF_WWW_URL'] || "https://www.#{chef_domain}"
+          extra_dispatch(url, extra)
         end
 
-        def chef_docs
-          @_docs ||= Site.new('docs')
+        def chef_blog_url(extra = nil)
+          url = ENV['CHEF_BLOG_URL'] || "#{chef_www_url}/blog"
+          extra_dispatch(url, extra)
         end
 
-        def chef_downloads
-          @_downloads ||= Site.new('downloads')
+        def chef_docs_url(extra = nil)
+          url = ENV['CHEF_DOCS_URL'] || "https://docs.#{chef_domain}"
+          extra_dispatch(url, extra)
         end
 
-        def chef_manage
-          @_manage ||= Site.new('manage', opscode_domain)
+        def chef_downloads_url(extra = nil)
+          url = ENV['CHEF_DOWNLOADS_URL'] || "https://downloads.#{chef_domain}"
+          extra_dispatch(url, extra)
         end
 
-        def learn_chef
-          @_learn ||= Site.new('learn')
+        def chef_identity_url
+          ENV['CHEF_IDENTITY_URL'] || "https://id.#{chef_domain}/id"
         end
 
-        def supermarket
-          @_supermarket ||= Site.new('supermarket')
+        def chef_manage_url
+          ENV['CHEF_MANAGE_URL'] || "https://manage.#{chef_domain}"
         end
 
-        def facebook_url 
+        def chef_sign_up_url
+          ENV['CHEF_SIGN_UP_URL'] || "#{chef_manage_url}/signup"
+        end
+
+        def learn_chef_url
+          ENV['LEARN_CHEF_URL'] || "https://learn.#{chef_domain}"
+        end
+
+        def supermarket_url
+          ENV['SUPERMARKET_URL'] || "https://supermarket.#{chef_domain}"
+        end
+
+        def chef_facebook_url 
           'https://www.facebook.com/getchefdotcom'
         end
 
-        def twitter_url 
+        def chef_twitter_url 
           'https://twitter.com/chef'
         end
 
-        def youtube_url 
+        def chef_youtube_url 
           'http://www.youtube.com/user/getchef'
         end
 
-        def linkedin_url 
+        def chef_linkedin_url 
           'https://www.linkedin.com/groups/Chef-Users-Group-3751378'
         end
 
+        private
+
+        def extra_dispatch(url, extra = nil)
+          if extra.nil?
+            url
+          else
+            "#{url}/#{extra}"
+          end
+        end
       end
     end
   end

--- a/spec/lib/oc/web/core/url_helpers_spec.rb
+++ b/spec/lib/oc/web/core/url_helpers_spec.rb
@@ -1,78 +1,51 @@
+require 'spec_helper'
 require 'oc/web/core/url_helpers'
 
 describe Chef::Web::Core::URLHelpers do
-  let(:application) { Object.new.extend(described_class) }
-  
-  describe 'for Chef sites' do
-    subject(:corpsite) { application.corpsite }
-    subject(:chef_docs) { application.chef_docs }
-    subject(:chef_downloads) { application.chef_downloads }
-    subject(:learn_chef) { application.learn_chef }
-    subject(:chef_manage) { application.chef_manage }
-    subject(:supermarket) { application.supermarket }
+  subject(:app) { Object.new.extend(described_class) }
 
-    it 'makes non-secure URLs' do
-      expect(corpsite.non_secure_url).to match(/^http:\/\/www\..+/)
-    end
-
-    it 'makes secure URLs' do
-      expect(supermarket.secure_url).to match(/^https:\/\/supermarket\..+/)
-    end
-
-    it 'makes protocol-relative URLs' do
-      expect(learn_chef.protocol_relative_url).to match(/^\/\/learn\..+/)
-    end
-
-    it 'makes canonical URLs' do
-      expect(chef_docs.canonical_url).to match(/^https:\/\/docs\..+/)
-    end
-
-    it 'defines a Corpsite' do
-      expect(corpsite).to be
-    end
-
-    it 'defines a Docs site' do
-      expect(chef_docs).to be
-    end
-
-    it 'defines a Downloads site' do
-      expect(chef_downloads).to be
-    end
-
-    it 'defines a Learn Chef site' do
-      expect(learn_chef).to be
-    end
-
-    it 'defines a Manage site' do
-      expect(chef_manage).to be
-    end
-
-    it 'defines a Supermarket' do
-      expect(supermarket).to be
-    end
-
-    it 'exposes a Site object' do
-      site = Chef::Web::Core::URLHelpers::Site.new('www', 'example.com')
-      expect(site).to respond_to(:subdomain, :domain, :hostname, :url, :to_s, :secure_url, :non_secure_url, :protocol_relative_url, :canonical_url)
-    end
+  before :each do
+    stub_const 'ENV', 'CHEF_DOMAIN' => 'chef.io'
   end
 
-  describe 'for third-party sites' do
+  its(:chef_domain)         { is_expected.to eq 'chef.io' }
+  its(:chef_server_url)     { is_expected.to eq 'https://api.chef.io' }
+  its(:chef_blog_url)       { is_expected.to eq 'https://www.chef.io/blog' }
+  its(:chef_docs_url)       { is_expected.to eq 'https://docs.chef.io' }
+  its(:chef_downloads_url)  { is_expected.to eq 'https://downloads.chef.io' }
+  its(:chef_identity_url)   { is_expected.to eq 'https://id.chef.io/id' }
+  its(:chef_manage_url)     { is_expected.to eq 'https://manage.chef.io' }
+  its(:chef_sign_up_url)    { is_expected.to eq 'https://manage.chef.io/signup' }
+  its(:learn_chef_url)      { is_expected.to eq 'https://learn.chef.io' }
+  its(:supermarket_url)     { is_expected.to eq 'https://supermarket.chef.io' }
+  its(:chef_facebook_url)   { is_expected.to eq 'https://www.facebook.com/getchefdotcom' }
+  its(:chef_twitter_url)    { is_expected.to eq 'https://twitter.com/chef' }
+  its(:chef_youtube_url)    { is_expected.to eq 'http://www.youtube.com/user/getchef' }
+  its(:chef_linkedin_url)   { is_expected.to eq 'https://www.linkedin.com/groups/Chef-Users-Group-3751378' }
 
-    it 'should generate a Facebook URL' do
-      expect(application.facebook_url).to match(/facebook/)
+  context 'with a CHEF_DOMAIN set' do
+    before :each do
+      ENV['CHEF_DOMAIN'] = 'chef.wtf'
     end
 
-    it 'should generate a Twitter URL ' do
-      expect(application.twitter_url).to match(/twitter/)
+    its(:chef_domain)       { is_expected.to eq 'chef.wtf' }
+    its(:chef_www_url)      { is_expected.to eq 'https://www.chef.wtf' }
+  end
+
+  context 'with no CHEF_DOMAIN set' do
+    before :each do
+      ENV.delete('CHEF_DOMAIN')
     end
 
-    it 'should generate a LinkedIn URL ' do
-      expect(application.linkedin_url).to match(/linkedin/)
+    its(:chef_domain)       { is_expected.to eq 'chef.io' }
+    its(:chef_www_url)      { is_expected.to eq 'https://www.chef.io' }
+  end
+
+  context 'with a site-specific environment variable set' do
+    before :each do
+      ENV['CHEF_IDENTITY_URL'] = 'https://identity.opscode.com'
     end
 
-    it 'should generate a YouTube URL ' do
-      expect(application.youtube_url).to match(/youtube/)
-    end
+    its(:chef_identity_url) { is_expected.to eq 'https://identity.opscode.com' }
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,1 @@
+require 'rspec/its'


### PR DESCRIPTION
This adds some URL helpers for use across Web properties.

This is two commits, the first of which was a simpler approach, but whose API gets sort of ugly when you deviate from the common case -- e.g.:

```
<%= link_to 'Corpsite', corpsite_url %>
```

vs.

```
<%= link_to 'Corpsite', protocol_relative_url_for(corpsite_host) %>
```

So I figured I'd refactor into a Site object, which lets you do this sort of thing instead:

```
<%= link_to 'Corpsite', corpsite.url %>
<%= link_to 'Corpsite', corpsite.protocol_relative_url %>
```

or just

```
<%= link_to 'Corpsite', corpsite %>
```

Thoughts?

@opscode/front-end 
