### PR TITLE
Fixes issues with www.chef.io not linking home

### DIFF
--- a/templates/corpsite_header.html.erb
+++ b/templates/corpsite_header.html.erb
@@ -19,7 +19,7 @@
       <div class="row">
         <div class="span12 col-md-12">
           <div class="navbar-inner navbar-header">
-            <a href="<%= chef_www_url} %>/" class="logo">
+            <a href="<%= chef_www_url %>/" class="logo">
               <img alt="Chef" onerror="this.src=<%= chef_www_url %>/images/logo.png" src="<%= chef_www_url %>/images/logo.svg" title="Chef">
             </a>
             <button  type="button" class="navbar-toggle" data-toggle="collapse" data-target="#c-navbar">


### PR DESCRIPTION
Changes url helpers to deal with leading / in extra and then puts a / in the call for the logo so that we can build the site with CHEF_WWW_URL = ''.

It really could use tests but I was having a hard time coming up with exactly what those should look like.

/cc @cnunciato 
