### PR TITLE
Forward arguments to $.fn.foundation

### DIFF
--- a/lib/assets/javascripts/chef/chef.js
+++ b/lib/assets/javascripts/chef/chef.js
@@ -33,7 +33,7 @@
   })();
 
   $.fn.chef = function() {
-    $(document).foundation();
+    $(document).foundation.apply(this, arguments);
 
     var args = Array.prototype.slice.call(arguments, 0);
 


### PR DESCRIPTION
Fixes #56. Example usage:

```
$(document).chef({ 
  tab: {
    callback: function(tab) {
      console.log(tab);
    }
  },
  accordion: {
    callback: function(accordion) {
      console.log(accordion);
    }
  }
});
```