### PR TITLE
fix broken links, and add missing <p>

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -22,7 +22,7 @@ helpers do
   end
 
   def download_url
-    "#{repo_url}/releases/download/#{current_version}/chef-web-core-#{current_version}.tgz"
+    "#{repo_url}/archive/#{current_version}.tar.gz"
   end
 end
 

--- a/source/getting-started.html.erb
+++ b/source/getting-started.html.erb
@@ -8,6 +8,7 @@ title: Getting Started
   need to know to get going.
 </p>
 <h3>Ruby</h3>
+<p>
   If you're running in a Ruby environment with Bundler and <a href="https://github.com/sstephenson/sprockets">Sprockets</a>,
   add the following line to your <code>Gemfile</code> to install from the <code>master</code> branch. (The repo is 
   currently private, so you'll need permissions to read it):


### PR DESCRIPTION
Am I right to change these in this way? Things like 
https://github.com/chef/chef-web-core/releases/download/0.1.4/chef-web-core-0.1.4.tgz
and
http://style.chef.io/dist/0.1.4/stylesheets/chef.css
such as currently appear on
http://style.chef.io/getting-started/
don't appear to exist, and the changes in this PR seem to point to what I presume are the right things.

Also the missing <p> makes some css selectors not fire and makes the `<code>` tags too big.