### PR TITLE
Compile and pack artifact when a Travis CI tag is detected

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -73,20 +73,23 @@ task :publish do
 
   if ENV['TRAVIS_BRANCH'] && ENV['TRAVIS_BRANCH'] != 'master'
     warn "Not going to deploy: $TRAVIS_BRANCH is #{ENV['TRAVIS_BRANCH']}, should be master."
-    exit 0
+    exit 0 unless ENV['TRAVIS_TAG']
   elsif ENV['TRAVIS_PULL_REQUEST'] && ENV['TRAVIS_PULL_REQUEST'] != 'false'
     warn "Not going to deploy: This is a pull request."
     exit 0
   end
 
   Rake::Task['compile'].execute
-  sh 'bundle exec middleman s3_sync'
-  sh 'bundle exec middleman invalidate'
 
   if ENV['TRAVIS_TAG']
+    warn "Tag detected. Continuing with artifact package building."
     sh 'npm run build'
     sh 'npm pack'
+    exit 0
   end
+
+  sh 'bundle exec middleman s3_sync'
+  sh 'bundle exec middleman invalidate'
 end
 
 desc 'Run all tests'


### PR DESCRIPTION
Previously, running `rake publish` on a tag would error with:

    /home/travis/.rvm/gems/ruby-1.9.3-p551/gems/dpl-1.7.11/lib/dpl/provider/s3.rb:37:in
    `chdir': No such file or directory - dist (Errno::ENOENT)

This is because when there's a tag, the `$TRAVIS_BRANCH` is the tag
name, not master, so compilation gets skipped. When compilation gets
skipped, there's no dist directory, and when there's no dist directory,
the upload fails.

This makes it so the compile still happens if there's a tag and
everything does what it did before if not.