### PR TITLE
revert github links from https://github.com/chef/chef-web-core/pull/69

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -22,7 +22,7 @@ helpers do
   end
 
   def download_url
-    "#{repo_url}/archive/#{current_version}.tar.gz"
+    "#{repo_url}/releases/download/#{current_version}/chef-web-core-#{current_version}.tgz"
   end
 end
 


### PR DESCRIPTION
Turns out the github links were never broken after all.