### PR TITLE
Bump foundation-rails, update gem dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,16 +2,11 @@ source 'https://rubygems.org'
 
 gemspec name: 'chef-web-core'
 
-# Use Middleman-stable for the conflation of these issues, which cause mayhem in test:
-# https://github.com/middleman/middleman-sprockets/issues/56
-# https://github.com/Compass/compass/issues/1529
-gem 'middleman', :github => 'middleman/middleman', :branch => 'v3-stable'
-
+gem 'middleman'
 gem 'middleman-core'
 gem 'middleman-cloudfront'
 gem 'middleman-s3_sync'
 gem 'middleman-livereload'
-gem 'sass', '~> 3.4.4'
 gem 'hologram'
 gem 'rake'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,37 +1,11 @@
-GIT
-  remote: git://github.com/middleman/middleman.git
-  revision: 35e01136fc7e8a924c3cf78a7ea90cf45a42050e
-  branch: v3-stable
-  specs:
-    middleman (3.3.9)
-      coffee-script (~> 2.2)
-      compass (>= 1.0.0, < 2.0.0)
-      compass-import-once (= 1.0.5)
-      execjs (~> 2.0)
-      haml (>= 4.0.5)
-      kramdown (~> 1.2)
-      middleman-core (= 3.3.9)
-      middleman-sprockets (>= 3.1.2)
-      sass (>= 3.4.0, < 4.0)
-      uglifier (~> 2.5)
-    middleman-core (3.3.9)
-      activesupport (~> 4.1.0)
-      bundler (~> 1.1)
-      erubis
-      hooks (~> 0.3)
-      i18n (~> 0.7.0)
-      listen (>= 2.7.9, < 3.0)
-      padrino-helpers (~> 0.12.3)
-      rack (>= 1.4.5, < 2.0)
-      rack-test (~> 0.6.2)
-      thor (>= 0.15.2, < 2.0)
-      tilt (~> 1.4.1, < 2.0)
-
 PATH
   remote: .
   specs:
     chef-web-core (0.1.6)
-      foundation-rails (= 5.5.1.0)
+      compass-rails (~> 2.0.4)
+      foundation-rails (= 5.5.1.1)
+      sass (>= 3.4.0, < 4.0)
+      sass-rails (>= 3.2.5)
 
 GEM
   remote: https://rubygems.org/
@@ -67,10 +41,10 @@ GEM
       ffi (~> 1.0, >= 1.0.11)
     chunky_png (1.3.4)
     coderay (1.1.0)
-    coffee-script (2.3.0)
+    coffee-script (2.4.1)
       coffee-script-source
       execjs
-    coffee-script-source (1.9.1)
+    coffee-script-source (1.9.1.1)
     compass (1.0.3)
       chunky_png (~> 1.2)
       compass-core (~> 1.0.2)
@@ -83,6 +57,10 @@ GEM
       sass (>= 3.3.0, < 3.5)
     compass-import-once (1.0.5)
       sass (>= 3.2, < 3.5)
+    compass-rails (2.0.4)
+      compass (~> 1.0.0)
+      sass-rails (<= 5.0.1)
+      sprockets (< 2.13)
     diff-lcs (1.2.5)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
@@ -90,7 +68,7 @@ GEM
     erubis (2.7.0)
     eventmachine (1.0.7)
     excon (0.44.2)
-    execjs (2.3.0)
+    execjs (2.5.2)
     ffi (1.9.6)
     fission (0.5.0)
       CFPropertyList (~> 2.2)
@@ -175,7 +153,7 @@ GEM
       fog-core
       nokogiri (~> 1.5, >= 1.5.11)
     formatador (0.2.5)
-    foundation-rails (5.5.1.0)
+    foundation-rails (5.5.1.1)
       railties (>= 3.1.0)
       sass (>= 3.3.0, < 3.5)
     git (1.2.9.1)
@@ -193,16 +171,39 @@ GEM
     inflecto (0.0.2)
     ipaddress (0.8.0)
     json (1.8.2)
-    kramdown (1.5.0)
-    listen (2.8.5)
-      celluloid (>= 0.15.2)
+    kramdown (1.6.0)
+    listen (2.10.0)
+      celluloid (~> 0.16.0)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
     map (6.5.5)
     method_source (0.8.2)
+    middleman (3.3.10)
+      coffee-script (~> 2.2)
+      compass (>= 1.0.0, < 2.0.0)
+      compass-import-once (= 1.0.5)
+      execjs (~> 2.0)
+      haml (>= 4.0.5)
+      kramdown (~> 1.2)
+      middleman-core (= 3.3.10)
+      middleman-sprockets (>= 3.1.2)
+      sass (>= 3.4.0, < 4.0)
+      uglifier (~> 2.5)
     middleman-cloudfront (0.1.1)
       fog (~> 1.9)
       middleman-core (~> 3.0)
+    middleman-core (3.3.10)
+      activesupport (~> 4.1.0)
+      bundler (~> 1.1)
+      erubis
+      hooks (~> 0.3)
+      i18n (~> 0.7.0)
+      listen (>= 2.7.9, < 3.0)
+      padrino-helpers (~> 0.12.3)
+      rack (>= 1.4.5, < 2.0)
+      rack-test (~> 0.6.2)
+      thor (>= 0.15.2, < 2.0)
+      tilt (~> 1.4.1, < 2.0)
     middleman-livereload (3.4.2)
       em-websocket (~> 0.5.1)
       middleman-core (>= 3.3)
@@ -215,7 +216,7 @@ GEM
       pmap
       ruby-progressbar
       unf
-    middleman-sprockets (3.4.1)
+    middleman-sprockets (3.4.2)
       middleman-core (>= 3.3)
       sprockets (~> 2.12.1)
       sprockets-helpers (~> 1.1.0)
@@ -229,11 +230,11 @@ GEM
     net-ssh (2.9.2)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
-    padrino-helpers (0.12.4)
+    padrino-helpers (0.12.5)
       i18n (~> 0.6, >= 0.6.7)
-      padrino-support (= 0.12.4)
+      padrino-support (= 0.12.5)
       tilt (~> 1.4.1)
-    padrino-support (0.12.4)
+    padrino-support (0.12.5)
       activesupport (>= 3.1)
     pmap (1.0.2)
     pry (0.10.1)
@@ -317,7 +318,7 @@ GEM
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uber (0.0.13)
-    uglifier (2.7.0)
+    uglifier (2.7.1)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
     unf (0.1.4)
@@ -337,7 +338,7 @@ DEPENDENCIES
   chef-web-core!
   git
   hologram
-  middleman!
+  middleman
   middleman-cloudfront
   middleman-core
   middleman-livereload
@@ -348,6 +349,5 @@ DEPENDENCIES
   rspec-core
   rspec-its
   rspec-rails
-  sass (~> 3.4.4)
   sass-rails (~> 5.0.0)
   selenium-webdriver

--- a/chef-web-core.gemspec
+++ b/chef-web-core.gemspec
@@ -16,7 +16,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'foundation-rails', '5.5.1.0'
+  spec.add_dependency 'foundation-rails', '5.5.1.1'
+  spec.add_dependency 'compass-rails', '~> 2.0.4'
+  spec.add_dependency 'sass-rails', '>= 3.2.5'
+  spec.add_dependency 'sass', '>= 3.4.0', '< 4.0'
 
   spec.add_development_dependency 'bundler', '~> 1.6'
 end

--- a/lib/assets/javascripts/chef/chef.js
+++ b/lib/assets/javascripts/chef/chef.js
@@ -1,3 +1,4 @@
+//= require foundation/foundation
 //= require foundation
 
 (function($, window, document) {

--- a/lib/assets/stylesheets/chef/base/_layout.scss
+++ b/lib/assets/stylesheets/chef/base/_layout.scss
@@ -34,15 +34,15 @@ Foundation provides [some very helpful helpers](http://foundation.zurb.com/docs/
 for working with media queries:
 
 ```
-@media #{$large-up} { 
+@media #{\$large-up} { 
   // These rules will apply to large screens and above 
 }
 
-@media #{$large-only} { 
+@media #{\$large-only} { 
   // These to large only
 }
 
-@media #{$medium-up} { 
+@media #{\$medium-up} { 
   // These to medium and above 
 }
 ```

--- a/lib/assets/stylesheets/oc.scss
+++ b/lib/assets/stylesheets/oc.scss
@@ -1,5 +1,4 @@
 @import 'oc/colors';
-
 @import 'oc/buttons';
 @import 'oc/footer';
 @import 'oc/header';

--- a/lib/assets/stylesheets/oc/buttons.scss
+++ b/lib/assets/stylesheets/oc/buttons.scss
@@ -1,3 +1,5 @@
+@import 'colors';
+
 // Buttons
 // =======
 .oc {

--- a/lib/assets/stylesheets/oc/header.scss
+++ b/lib/assets/stylesheets/oc/header.scss
@@ -6,6 +6,7 @@
 @import "compass/css3/transform";
 @import 'compass/css3/transition';
 
+@import 'colors';
 @import 'oc/header/getchef-button';
 @import 'oc/header/logo';
 

--- a/lib/chef/web/core/engine.rb
+++ b/lib/chef/web/core/engine.rb
@@ -18,6 +18,9 @@ class Chef
             end
           end
 
+          require 'compass'
+          Sass.load_paths << Compass::Frameworks['compass'].stylesheets_directory
+
           app.config.assets.precompile += %w(
             *.css
             *.js


### PR DESCRIPTION
Makes gem dependencies more explicit. If you're using this now with a Middleman app, you might need to update to the current version (3.3.10 as of today) to avoid conflicts with Compass and Sass.



