### PR TITLE
Publish merges to master and tagged commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ accordingly:
 
 This'll update the appropriate files, commit and tag the release for you, but it won't push it 
 to Github. You can do that yourself when you're ready:
-
+    
+    git push origin master
     git push origin --tags 
 
 When the tests pass, Travis will run the `publish` task, which will deploy the style-guide site to 

--- a/config.rb
+++ b/config.rb
@@ -52,6 +52,12 @@ unless test?
     # to ignore remote resources by pattern. 
     s3_sync.delete = false
   end 
+
+  activate :cloudfront do |cloudfront|
+    cloudfront.access_key_id     = ENV['AWS_ACCESS_KEY_ID']
+    cloudfront.secret_access_key = ENV['AWS_SECRET_ACCESS_KEY']
+    cloudfront.distribution_id   = ENV['CLOUDFRONT_DISTRIBUTION_ID']
+  end
 end
 
 configure :development do
@@ -73,12 +79,6 @@ configure :development do
 
     delayed.kill
   end
-end
-
-activate :cloudfront do |cloudfront|
-  cloudfront.access_key_id     = ENV['AWS_ACCESS_KEY_ID']
-  cloudfront.secret_access_key = ENV['AWS_SECRET_ACCESS_KEY']
-  cloudfront.distribution_id   = ENV['CLOUDFRONT_DISTRIBUTION_ID']
 end
 
 configure :build do


### PR DESCRIPTION
Currently, we build asset packages on tagged commits, but we exit before publishing the site. We should publish on tagged commits because the site displays the current version number and links to asset packages on GitHub releases. This makes that so.

It also fixes a bug preventing the site from being published on merges to master because of the TRAVIS_TAG environment variable containing an empty string (so always evaluating true).

Lastly it suppresses cloudfront activation during tests.