### PR TITLE
Include, use Modernizr

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -56,6 +56,14 @@ module.exports = function(grunt) {
             cwd: foundationSource + '/vendor/assets/stylesheets',
             src: ['foundation.scss', 'normalize.scss', 'foundation/**'], 
             dest: distDir('scss/vendor')
+          },
+
+          // Copy in vendored scripts
+          {
+            expand: true,
+            cwd: foundationSource + '/vendor/assets/javascripts/vendor',
+            src: ['modernizr.js'],
+            dest: distDir('javascripts/vendor')
           }
         ],
       },

--- a/config.rb
+++ b/config.rb
@@ -31,6 +31,8 @@ set :images_dir, 'assets/images'
 set :css_dir, 'assets/stylesheets'
 set :js_dir, 'assets/javascripts'
 
+sprockets.import_asset 'vendor/modernizr'
+
 def test?
   ENV['MIDDLEMAN_ENV'] == 'test'
 end

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><%= current_page.data.title %> | Chef Style Guide</title>
-    <%= javascript_include_tag '//cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js' %>
+    <%= javascript_include_tag 'vendor/modernizr' %>
     <%= stylesheet_link_tag 'chef-web-core' %>
     <%= stylesheet_link_tag 'github' %>
     <%= stylesheet_link_tag 'guide' %>

--- a/spec/dummy/rails/app/views/layouts/application.html.erb
+++ b/spec/dummy/rails/app/views/layouts/application.html.erb
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>My Awesome App</title>
     <%= stylesheet_link_tag 'all' %>
-    <%= javascript_include_tag '//cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js' %>
+    <%= javascript_include_tag 'vendor/modernizr' %>
     <%= csrf_meta_tags %>
   </head>
   <body>


### PR DESCRIPTION
This uses the vendored Modernizr.js included with foundation-rails and adds it to the asset package. Fixes #52.