### PR TITLE
Restore Foundation globals

### DIFF
--- a/lib/assets/stylesheets/chef/_settings.scss
+++ b/lib/assets/stylesheets/chef/_settings.scss
@@ -1,3 +1,5 @@
+@import 'foundation/components/global';
+
 $chef-orange:                     #f18b21;
 $chef-dark-blue:                  #3f5364;
 $chef-light-blue:                 #6bb2e2;

--- a/lib/assets/stylesheets/oc/header.scss
+++ b/lib/assets/stylesheets/oc/header.scss
@@ -1,7 +1,6 @@
 // Header
 // ======
 
-@import 'oc/colors';
 @import "compass/css3/box-shadow";
 @import "compass/css3/images";
 @import "compass/css3/transform";


### PR DESCRIPTION
A previous commit removed the Foundation `_type` component (which imports a handful of Foundation variables) from `_settings.scss`. This restores access to those variables by importing the `_globals` component explicitly, and also removes an unnecessary line from `oc/header'.