### PR TITLE
Tweak the .alert-box.info colors

### DIFF
--- a/lib/assets/stylesheets/chef/components/alert.scss
+++ b/lib/assets/stylesheets/chef/components/alert.scss
@@ -35,3 +35,12 @@ category: Alert
 
 @import '../settings';
 @import 'foundation/components/alert-boxes';
+
+.alert-box.info {
+  a {
+    color: scale-color($info-color, $lightness: 70%);
+    &:hover {
+      color: scale-color($info-color, $lightness: 90%);
+    }
+  }
+}

--- a/lib/assets/stylesheets/chef/themes/_default.scss
+++ b/lib/assets/stylesheets/chef/themes/_default.scss
@@ -17,10 +17,18 @@ The default theme.
 
 $theme:                             $theme-default !default;
 $chef-palette-link-color:           $chef-dark-blue !default;
-$topbar-link-color:                 $chef-dark-blue !default;
-$topbar-link-font-size:             16px !default;
-$topbar-bg:                         $chef-white !default;
+
+// Alert
+$alert-border-style:                none;
+$info-color:                        #81A9CC;
+
+// Type
 $chef-type-font-urls:               '//fonts.googleapis.com/css?family=Montserrat:400';
 $chef-type-label:                   Montserrat, "Helvetica Neue", Helvetica, Arial, sans-serif !default;
 $chef-type-code:                    Consolas, Liberation Mono, Courier, monospace !default;
 $code-font-family:                  $chef-type-code !default;
+
+// Top Bar
+$topbar-link-color:                 $chef-dark-blue !default;
+$topbar-link-font-size:             16px !default;
+$topbar-bg:                         $chef-white !default;

--- a/source/assets/stylesheets/guide.scss
+++ b/source/assets/stylesheets/guide.scss
@@ -1,6 +1,5 @@
 @import 'chef/settings';
 @import 'foundation/components/type';
-@import 'foundation/components/alert-boxes';
 
 $code-padding: 12px;
 


### PR DESCRIPTION
Knocks down the background color of alert-info boxes, and makes hrefs look nicer inside them.

![](http://cl.ly/image/1Z0C24461B1B/Image%202015-05-08%20at%204.58.18%20PM.png)

/cc @rmoshier 

