### PR TITLE
Drop headings down a bit

### DIFF
--- a/lib/assets/stylesheets/chef/base/_typography.scss
+++ b/lib/assets/stylesheets/chef/base/_typography.scss
@@ -24,4 +24,11 @@ category: Typography
   }
 }
 
+$h1-font-size: rem-calc(36);
+$h2-font-size: rem-calc(28);
+$h3-font-size: rem-calc(24);
+$h4-font-size: rem-calc(18);
+$h5-font-size: rem-calc(16);
+$h6-font-size: 1rem;
+
 @import 'foundation/components/type';

--- a/source/assets/stylesheets/guide.scss
+++ b/source/assets/stylesheets/guide.scss
@@ -1,4 +1,5 @@
 @import 'chef/settings';
+@import 'chef/base/typography';
 @import 'foundation/components/type';
 
 $code-padding: 12px;


### PR DESCRIPTION
The `h` tags in Foundation are too big. This drops them all down a notch.