### PR TITLE
Use yellow for the alert-warning color

### DIFF
--- a/lib/assets/stylesheets/chef/themes/_default.scss
+++ b/lib/assets/stylesheets/chef/themes/_default.scss
@@ -22,6 +22,7 @@ $logo-accent-color:                 $chef-orange !default;
 // Alert
 $alert-border-style:                none;
 $info-color:                        #81A9CC;
+$warning-color:                     $chef-yellow;
 
 // Type
 $chef-type-font-urls:               '//fonts.googleapis.com/css?family=Montserrat:400';


### PR DESCRIPTION
Orange conflicts with form elements and other various uses of orange. Yellow is standard, we have a yellow defined on the palette. We should use that instead.