### PR TITLE
Add Nokogiri to the Gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gem 'middleman-cloudfront'
 gem 'middleman-s3_sync'
 gem 'middleman-livereload'
 gem 'hologram'
-gem 'nokogiri'
 gem 'rake'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     chef-web-core (0.3.0)
       compass-rails (~> 2.0.4)
       foundation-rails (= 5.5.1.1)
+      nokogiri
       sass (>= 3.4.0, < 4.0)
       sass-rails (>= 3.2.5)
 
@@ -344,7 +345,6 @@ DEPENDENCIES
   middleman-core
   middleman-livereload
   middleman-s3_sync
-  nokogiri
   pry
   rack-cors
   rake

--- a/chef-web-core.gemspec
+++ b/chef-web-core.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'compass-rails', '~> 2.0.4'
   spec.add_dependency 'sass-rails', '>= 3.2.5'
   spec.add_dependency 'sass', '>= 3.4.0', '< 4.0'
+  spec.add_dependency 'nokogiri'
 
   spec.add_development_dependency 'bundler', '~> 1.6'
 end


### PR DESCRIPTION
AssetHelpers requires Nokogiri. This moves the dependency declaration
from the style guide's Gemfile to web-core's Gemspec where it belongs.