### PR TITLE
Removes supermarket anchor from community link

### DIFF
--- a/templates/corpsite_header.html.erb
+++ b/templates/corpsite_header.html.erb
@@ -4,7 +4,7 @@
       <div class="span12 col-md-12">
         <div class="sign-in-container text-right">
           <div class="login-links">
-            <a href="https://docs.chef.io/community.html#supermarket">Community</a>
+            <a href="https://docs.chef.io/community.html">Community</a>
             <a href="<%= chef_blog_url %>">Blog</a>
             <a href="<%= chef_www_url('support/') %>">Support</a>
             <a href="<%= chef_account_management_url %>">Account</a>
@@ -68,7 +68,7 @@
               <li id="responsive-sign-links" class="visible-phone visible-xs">
                 <ul>
                   <li>
-                    <a href="https://docs.chef.io/community.html#supermarket">Community</a>
+                    <a href="https://docs.chef.io/community.html">Community</a>
                   </li>
                   <li>
                     <a href="<%= chef_blog_url %>">Blog</a>


### PR DESCRIPTION
Originally marketing requested that we link to the supermarket section
of the page, but upon review in acceptance, the decision was made to
instead use the link with no anchor.